### PR TITLE
Removing PE from the list of VALID_FILES

### DIFF
--- a/src/thrember/download.py
+++ b/src/thrember/download.py
@@ -4,7 +4,7 @@ import argparse
 from huggingface_hub import hf_hub_download, list_repo_files
 
 VALID_SPLITS = ["all", "train", "test", "challenge"]
-VALID_FILES = ["all", "PE", "Win32", "Win64", "Dot_Net", "APK", "ELF", "PDF"]
+VALID_FILES = ["all", "Win32", "Win64", "Dot_Net", "APK", "ELF", "PDF"]
 
 
 def is_dir(file_path):


### PR DESCRIPTION
Fixes #2 

Removing PE from the list of VALID_FILES, as that was split up into Win32 and Win64. This should fix issues downloading the data.