### PR TITLE
Fixed email regex in features computation

### DIFF
--- a/src/thrember/features.py
+++ b/src/thrember/features.py
@@ -199,7 +199,7 @@ class StringExtractor(FeatureType):
             "ipv4_addr": re.compile("\\b(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\b"),
             "ipv6_addr": re.compile("\\b(?:[A-Fa-f0-9]{1,4}:){7}[A-Fa-f0-9]{1,4}\\b|\\b(?:[A-Fa-f0-9]{1,4}:){1,7}:\\b|\\b:[A-Fa-f0-9]{1,4}(?::[A-Fa-f0-9]{1,4}){1,6}\\b"),
             "mac_addr": re.compile("\\b(?:[0-9A-Fa-f]{2}[:-]){5}(?:[0-9A-Fa-f]{2})\\b"),
-            "email_addr": re.compile("\\b(?:[0-9A-Fa-f]{2}[:-]){5}(?:[0-9A-Fa-f]{2})\\b"),
+            "email_addr": re.compile("[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}"),
             "btc_wallet": re.compile("[13][a-km-zA-HJ-NP-Z1-9]{25,34}"),
 
             # Windows strings


### PR DESCRIPTION
Likely a copy-paste failure ; the current [`email_addr`](https://github.com/dhondta/EMBER2024/blob/main/src/thrember/features.py#L202) regex is the same as [`mac_addr`](https://github.com/dhondta/EMBER2024/blob/main/src/thrember/features.py#L201) and differs from the [original regex](https://github.com/StackZeroSec/string_analyzer/blob/main/patterns.json#L6C15-L6C62).