### PR TITLE
Fix challenge_metadf to utilize challenge_records

### DIFF
--- a/src/thrember/model.py
+++ b/src/thrember/model.py
@@ -298,7 +298,7 @@ def read_metadata(data_dir: Path | str) -> pl.DataFrame:
 
     challenge_feature_paths = gather_feature_paths(data_path, "challenge")
     challenge_records = list(pool.imap(read_metadata_record, raw_feature_iterator(challenge_feature_paths)))
-    challenge_metadf = pl.DataFrame(test_records).with_columns(subset=pl.lit("challenge")).select(ORDERED_COLUMNS)
+    challenge_metadf = pl.DataFrame(challenge_records).with_columns(subset=pl.lit("challenge")).select(ORDERED_COLUMNS)
 
     return train_metadf, test_metadf, challenge_metadf
 


### PR DESCRIPTION
## Summary
Fix metadata creation for the challenge subset.

## Changes
- use `challenge_records` instead of `test_records` when building `challenge_metadf`
- keep the `subset="challenge"` assignment consistent
- remove the incorrect intermediate assignment

## Why
Previously, `challenge_metadf` was first built from `test_records`, which could lead to wrong metadata being associated with the challenge split. This PR ensures that the challenge dataframe is always created from `challenge_records`.